### PR TITLE
feat(datastore): datastore state management 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tabler/icons-react": "^2.23.0",
         "astro": "^2.7.0",
         "clsx": "^1.2.1",
+        "immer": "^10.0.2",
         "nanoid": "^4.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2977,6 +2978,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/import-meta-resolve": {
       "version": "2.2.2",
@@ -8558,6 +8568,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA=="
     },
     "import-meta-resolve": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tabler/icons-react": "^2.23.0",
     "astro": "^2.7.0",
     "clsx": "^1.2.1",
+    "immer": "^10.0.2",
     "nanoid": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/app/datavizs/data/index.tsx
+++ b/src/app/datavizs/data/index.tsx
@@ -1,0 +1,29 @@
+import { DataTable } from "@/components/react";
+import type { FC } from "react";
+import { useStore } from "../store/data-store";
+
+export const Data: FC<{ dataId: string }> = ({ dataId }) => {
+  const data = useStore((state) => state.dataStore[dataId]);
+
+  const metadata = useStore((state) => state.metadata[dataId]);
+
+  if (data === undefined || metadata === undefined) return null;
+
+  return (
+    <DataTable
+      search
+      _id="_id"
+      data={data}
+      title={metadata.name}
+      columns={metadata.columns}
+      createRow={() => useStore.getState().addRow(dataId)}
+      edit={(_id, data) => useStore.getState().updateRow(dataId, _id, data)}
+      createColumn={(column) => useStore.getState().addColumn(dataId, column)}
+      sort={(name, type) => useStore.getState().sortColumn(dataId, name, type)}
+      remove={(type, data) => {
+        if (type === "row") useStore.getState().deleteRow(dataId, data);
+        if (type === "column") useStore.getState().deleteColumns(dataId, data);
+      }}
+    />
+  );
+};

--- a/src/app/datavizs/index.tsx
+++ b/src/app/datavizs/index.tsx
@@ -1,27 +1,49 @@
-import type { FC } from "react";
-import { MantineProvider, DataTable } from "@/components/react";
-import { Button, Tabs, useMantineColorScheme } from "@mantine/core";
-import { useDataStore } from "./store/data-store";
+import { useState, type FC } from "react";
+import { useStore } from "./store/data-store";
+import { MantineProvider } from "@/components/react";
+import {
+  IconDatabase,
+  IconMoon,
+  IconSun,
+  IconTable,
+  IconTableFilled,
+} from "@tabler/icons-react";
+import {
+  Tabs,
+  Tooltip,
+  Button,
+  ActionIcon,
+  useMantineColorScheme,
+  ScrollArea,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
+import { Data } from "./data";
+import clsx from "clsx";
 
-const App = () => {
+const MantineDarkMode = () => {
   const { setColorScheme, colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === "dark";
   return (
-    <Button
-      color="blue"
-      onClick={() =>
-        colorScheme === "dark"
-          ? setColorScheme("light")
-          : setColorScheme("dark")
-      }
-    >
-      {colorScheme !== "dark" ? "Light" : "Dark"}
-    </Button>
+    <Tooltip label="Toggle Dark Mode">
+      <ActionIcon
+        variant="default"
+        onClick={() => setColorScheme(isDark ? "light" : "dark")}
+      >
+        {isDark ? (
+          <IconSun className="w-4 h-4" />
+        ) : (
+          <IconMoon className="w-4 h-4" />
+        )}
+      </ActionIcon>
+    </Tooltip>
   );
 };
 
 const Datavizs: FC = () => {
-  const data = useDataStore((state) => state.data);
-  const column = useDataStore((state) => state.columns);
+  const [dataId, setDataId] = useState<string>("");
+
+  const metadata = useStore((state) => state.metadata);
 
   return (
     <MantineProvider>
@@ -31,9 +53,18 @@ const Datavizs: FC = () => {
         defaultValue="data"
         classNames={{ root: "h-screen flex !flex-col p-1" }}
       >
-        <Tabs.List>
-          <Tabs.Tab value="data">Data</Tabs.Tab>
-          <Tabs.Tab value="visualization">Visualization</Tabs.Tab>
+        <Tabs.List className="flex items-center">
+          <div className="flex-1 flex items-center">
+            <Tabs.Tab value="data">Data</Tabs.Tab>
+            <Tabs.Tab value="visualization">Visualization</Tabs.Tab>
+          </div>
+          <Button
+            size="compact-sm"
+            onClick={() => useStore.getState().createData()}
+          >
+            Add Dummy Data
+          </Button>
+          <MantineDarkMode />
         </Tabs.List>
 
         <Tabs.Panel
@@ -41,9 +72,7 @@ const Datavizs: FC = () => {
           classNames={{ panel: "flex !flex-1" }}
           className="flex overflow-hidden pt-2 border-t dark:border-gray-700 mt-2"
         >
-          <div>
-            <App />
-          </div>
+          <div></div>
         </Tabs.Panel>
 
         <Tabs.Panel
@@ -52,27 +81,38 @@ const Datavizs: FC = () => {
           className="flex overflow-hidden border-t dark:border-gray-700 mt-2"
         >
           <div className="flex-1 flex flex-row">
-            <div className="w-80"></div>
-            <DataTable
-              search
-              _id="_id"
-              title="Data table"
-              columns={column}
-              data={data}
-              sort={(name, type) =>
-                useDataStore.getState().sortColumn(name, type)
-              }
-              edit={(_id, data) => useDataStore.getState().updateRow(_id, data)}
-              remove={(type, data) => {
-                if (type === "row") useDataStore.getState().deleteRows(data);
-                if (type === "column")
-                  useDataStore.getState().deleteColumns(data);
-              }}
-              createRow={() => useDataStore.getState().addRow()}
-              createColumn={(column) => {
-                useDataStore.getState().addColumn(column);
-              }}
-            />
+            <div className="w-80 flex flex-col p-1 text-gray-700">
+              <ScrollArea className="flex-1">
+                {Object.keys(metadata).map((item) => (
+                  <UnstyledButton
+                    key={item}
+                    onClick={() => setDataId(item)}
+                    className="w-full"
+                  >
+                    <div
+                      className={clsx(
+                        "flex items-center hover:bg-gray-100 border-b",
+                        item === dataId && "bg-gray-100"
+                      )}
+                    >
+                      <IconTableFilled
+                        strokeWidth={1}
+                        className="text-gray-500 w-8 h-8"
+                      />
+                      <div className="flex-1 flex flex-col space-y-1 py-1 px-2 mb-1">
+                        <Text size="sm" fw={600}>
+                          {metadata[item].name}
+                        </Text>
+                        <span className="text-xs italic">
+                          {metadata[item].createdAt.toDateString()}
+                        </span>
+                      </div>
+                    </div>
+                  </UnstyledButton>
+                ))}
+              </ScrollArea>
+            </div>
+            <Data dataId={dataId} />
           </div>
         </Tabs.Panel>
       </Tabs>

--- a/src/app/datavizs/store/dummy.ts
+++ b/src/app/datavizs/store/dummy.ts
@@ -1,0 +1,40 @@
+import { faker } from "@faker-js/faker";
+
+export const createMetadata = (): MetaData => ({
+  name: faker.finance.accountName(),
+  createdAt: new Date(),
+  columns: [
+    {
+      name: "_id",
+      type: "id",
+    },
+    {
+      name: "name",
+      type: "string",
+    },
+    {
+      name: "email",
+      type: "string",
+    },
+    {
+      name: "age",
+      type: "number",
+    },
+    {
+      name: "gender",
+      type: "string",
+    },
+  ],
+});
+
+export const createData = () =>
+  faker.helpers.multiple(
+    () => ({
+      _id: faker.string.nanoid(10),
+      name: faker.person.fullName(),
+      email: faker.internet.email(),
+      age: faker.number.int({ min: 10, max: 70 }),
+      gender: faker.person.sex(),
+    }),
+    { count: 1000 }
+  );

--- a/src/app/datavizs/store/types.ts
+++ b/src/app/datavizs/store/types.ts
@@ -1,0 +1,47 @@
+type ColumnType = "string" | "number" | "id";
+
+interface Column {
+  name: string;
+  type: ColumnType;
+}
+
+interface FlatObject {
+  _id: string;
+  [key: string]: any;
+}
+
+interface MetaData {
+  name: string;
+  createdAt: Date;
+  columns: Column[];
+}
+
+interface State {
+  metadata: {
+    [id: string]: MetaData;
+  };
+  dataStore: {
+    [id: string]: FlatObject[];
+  };
+}
+
+
+interface Action {
+  createData: () => void;
+
+  getData: (dataId: string) => FlatObject[];
+
+  deleteData: (dataId: string[]) => void;
+
+  addColumn: (dataId: string, column: Column) => void;
+
+  deleteColumns: (dataId: string, names: string[]) => void;
+
+  sortColumn: (dataId: string, name: string, type: "asc" | "desc") => void;
+
+  addRow: (dataId: string) => void;
+
+  deleteRow: (dataId: string, _ids: string[]) => void;
+
+  updateRow: (dataId: string, _id: string, data: FlatObject) => void;
+}


### PR DESCRIPTION
changes in this PR:

- using zustand with immer middleware in `data-store`
- multiple data and metadata in object instead array, because it is easier to access than array
- add data using fake data

close #29  